### PR TITLE
Makes all garden stuff lattices get constructed in the same way

### DIFF
--- a/scripts/garden_stuff.zs
+++ b/scripts/garden_stuff.zs
@@ -1,0 +1,37 @@
+import minetweaker.item.IIngredient;
+import minetweaker.item.IItemStack;
+
+var latticeIngredients = [
+    <ore:ingotIron>,
+    <ore:ingotWroughtIron>,
+    <minecraft:planks:0>,
+    <minecraft:planks:1>,
+    <minecraft:planks:2>,
+    <minecraft:planks:3>,
+    <minecraft:planks:4>,
+    <minecraft:planks:5>
+] as IIngredient[];
+
+var outputLattices = [
+    <GardenStuff:lattice:0>,
+    <GardenStuff:lattice:2>,
+    <GardenStuff:lattice_wood:0>,
+    <GardenStuff:lattice_wood:1>,
+    <GardenStuff:lattice_wood:2>,
+    <GardenStuff:lattice_wood:3>,
+    <GardenStuff:lattice_wood:4>,
+    <GardenStuff:lattice_wood:5>
+] as IItemStack[];
+
+for i, ingr in latticeIngredients {
+    var output = outputLattices[i];
+
+    recipes.removeShaped(output);
+    recipes.addShaped(output * 16,
+        [
+            [ingr, null, ingr],
+            [null, ingr, null],
+            [ingr, null, ingr]
+        ]
+    );
+}

--- a/scripts/iron_lattice.zs
+++ b/scripts/iron_lattice.zs
@@ -1,4 +1,0 @@
-recipes.removeShaped(<GardenStuff:lattice> * 16, [[null, <minecraft:iron_ingot>, null], [<minecraft:iron_ingot>, <minecraft:iron_ingot>, <minecraft:iron_ingot>], [null, <minecraft:iron_ingot>, null]]);
-
-
-recipes.addShaped(<GardenStuff:lattice> * 16, [[<minecraft:iron_ingot>, null, <minecraft:iron_ingot>], [null, <minecraft:iron_ingot>, null], [<ore:ingotIron>, null, <minecraft:iron_ingot>]]);


### PR DESCRIPTION
The wooden lattice recipe overlapped with wooden gears so I made all of them switched to the new recipe

Also makes the ore dictionary support work properly